### PR TITLE
IJToImg: fix type guessing for scaled images

### DIFF
--- a/org.knime.knip.imagej2.core/src/org/knime/knip/imagej2/core/util/IJToImg.java
+++ b/org.knime.knip.imagej2.core/src/org/knime/knip/imagej2/core/util/IJToImg.java
@@ -89,7 +89,7 @@ public final class IJToImg<T extends RealType<T> & NativeType<T>> implements
         switch (op.getBitDepth()) {
             case 8:
                 final ImageStatistics is = op.getStatistics(Measurements.AREA);
-                if ((is.histogram[0] + is.histogram[is.histogram.length - 1]) == is.area) {
+                if ((is.histogram[0] + is.histogram[is.histogram.length - 1]) == is.pixelCount) {
                     return new BitType();
                 }
                 return new UnsignedByteType();


### PR DESCRIPTION
`is.area` is the measured area in calibrated spatial units not pixels.