### PR TITLE
SettingsModelImageJDlg: add extra handling of @File parameters

### DIFF
--- a/org.knime.knip.imagej2.core/src/org/knime/knip/imagej2/core/imagejdialog/SettingsModelImageJDlg.java
+++ b/org.knime.knip.imagej2.core/src/org/knime/knip/imagej2/core/imagejdialog/SettingsModelImageJDlg.java
@@ -50,6 +50,7 @@ package org.knime.knip.imagej2.core.imagejdialog;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -219,6 +220,8 @@ public class SettingsModelImageJDlg extends SettingsModel {
                 item = settings.getString(keys[i]);
             } else if (types[i].equals(Boolean.class.getSimpleName())) {
                 item = settings.getBoolean(keys[i]);
+            } else if (types[i].equals(File.class.getSimpleName())) {
+                item = new File(settings.getString(keys[i]));
             } else {
                 final String itemString = settings.getString(keys[i]);
                 item = stringToObject(itemString);
@@ -275,6 +278,9 @@ public class SettingsModelImageJDlg extends SettingsModel {
             } else if (item instanceof Boolean) {
                 settings.addBoolean(keys[i], (Boolean)item);
                 types[i] = Boolean.class.getSimpleName();
+            } else if (item instanceof File) {
+                settings.addString(keys[i], ((File)item).getAbsolutePath());
+                types[i] = File.class.getSimpleName();
             } else {
                 final String itemString = objectToString(item);
                 types[i] = "OTHER";


### PR DESCRIPTION
`@File` parameters are internally stored with type `OTHER`. Hence they are serialized/deserialized via a Base64 encoding. Such parameters, cannot be controlled with a `String` flow variable although the dialog allows the user to: the attempt to deserialize the content of the flow variable, which is not Base64 encoded is, fails with a `NullPointerException`.