### PR TITLE
Log skipped modules during module discovery

### DIFF
--- a/org.knime.knip.imagej2.core/src/org/knime/knip/imagej2/core/IJGateway.java
+++ b/org.knime.knip.imagej2.core/src/org/knime/knip/imagej2/core/IJGateway.java
@@ -222,11 +222,11 @@ public final class IJGateway {
         for (final ModuleInfo info : modules) {
 
             if (!info.canRunHeadless()) {
-                LOGGER.debug("Skipping non-headless-compatible module: {}", info);
+                LOGGER.debug("Skipping non-headless-compatible module: " + info);
                 continue;
             }
             if (isDynamicPlugin(info)) {
-                LOGGER.debug("Skipping dynamic module: {}", info);
+                LOGGER.debug("Skipping dynamic module: " + info);
                 continue;
             }
 
@@ -241,7 +241,8 @@ public final class IJGateway {
                     final Class<?> type = item.getType();
                     hasInOrOutput = true;
                     if (!isSupportedInputType(info, type)) {
-                        LOGGER.debug("Unsupported input '{}' of type '{}' for module: {}", item.getName(), type.getName(), info);
+                        LOGGER.debug("Unsupported input '" + item.getName() + "' of type '" + type.getName()
+                                + "' for module: " + info);
                         inputsOK = false;
                     }
                 }
@@ -252,14 +253,17 @@ public final class IJGateway {
                     final Class<?> type = item.getType();
                     hasInOrOutput = true;
                     if (!isSupportedOutputType(type)) {
-                        LOGGER.debug("Unsupported output '{}' of type '{}' for module: {}", item.getName(), type.getName(), info);
+                        LOGGER.debug("Unsupported output '" + item.getName() + "' of type '" + type.getName()
+                                + "' for module: " + info);
                         outputsOK = false;
                     }
                 }
-                if (!inputsOK || !outputsOK) continue;
+                if (!inputsOK || !outputsOK) {
+                    continue;
+                }
 
                 if (!hasInOrOutput) {
-                    LOGGER.debug("No inputs or outputs for module: {}", info);
+                    LOGGER.debug("No inputs or outputs for module: " + info);
                     continue;
                 }
 


### PR DESCRIPTION
During the DAIS Learnathon 2019, several students had an issue where the ImageJ2 command they made did not appear as a KNIME node as expected. People were speculating on what the problem(s) might be, but it was hard to know since the module discovery does not currently log most reasons why a module might be excluded during discovery. This patch adds more debug logging, to help make the reasons clearer.

Note that I did not compile/test this patch yet, since I didn't have a KNIME development environment set up at the time of this writing.